### PR TITLE
 커뮤니티 페이지 영상 변경 안되는 에러 해결

### DIFF
--- a/src/Page/Community/components/Community.tsx
+++ b/src/Page/Community/components/Community.tsx
@@ -336,11 +336,12 @@ const Community = () => {
               <div className={styles.video}>
                 <video
                   id="videoPlayer"
+                  src={videoDetailData.video}
                   controls
                   controlsList="nodownload"
                   onContextMenu={e => e.preventDefault()}
                 >
-                  <source src={videoDetailData.video} type="video/mp4" />
+                  {/* <source src={videoDetailData.video} type="video/mp4" /> */}
                 </video>
               </div>
               <div className={styles.group}>


### PR DESCRIPTION
### #️⃣ Issue Number

- close #188 

### ✏️Task

- [x] 커뮤니티 페이지 영상 변경 안되는 에러 해결

### ✏️Tasks Description

- 커뮤니티 페이지 영상 변경 안되는 에러 해결
- video 태그에서 source 대신 직접 video 태그에 src를 사용하여 해결

### 🗓Next Task

- [x] x
